### PR TITLE
Add Saloon Brewmaster to Standard Handbuff DK definition

### DIFF
--- a/lib/backend/deck_archetyper/death_knight_archetyper.ex
+++ b/lib/backend/deck_archetyper/death_knight_archetyper.ex
@@ -107,7 +107,8 @@ defmodule Backend.DeckArchetyper.DeathKnightArchetyper do
         "Vicious Bloodworm",
         "Overlord Runthak",
         "Ram Commander",
-        "Encumbered Pack Mule"
+        "Encumbered Pack Mule",
+        "Saloon Brewmaster"
       ])
 
   def wild(card_info) do


### PR DESCRIPTION
It is used to bounce back the hero power minion
Some decks are missed without it