### PR TITLE
Shorten Demon Hunter deck names

### DIFF
--- a/lib/backend/deck_archetyper/demon_hunter_archetyper.ex
+++ b/lib/backend/deck_archetyper/demon_hunter_archetyper.ex
@@ -210,10 +210,10 @@ defmodule Backend.DeckArchetyper.DemonHunterArchetyper do
 
     cond do
       highlander?(card_info) ->
-        String.to_atom("Highlander #{class_name}")
+        :"Highlander DH"
 
       questline?(card_info) ->
-        String.to_atom("Questline #{class_name}")
+        :"Questline DH"
 
       quest?(card_info) ->
         String.to_atom("#{quest_abbreviation(card_info)} Quest #{class_name}")


### PR DESCRIPTION
"XL Questline Demon Hunter" and
"XL Highlander Demon Hunter"
deck names do not fit in their divs
https://www.hsguru.com/decks?format=1&min_games=50&period=patch_29.6.0&player_class=DEMONHUNTER&rank=diamond_to_legend