### PR TITLE
Add Floppy Hydra Hunter to wild

### DIFF
--- a/lib/backend/deck_archetyper/hunter_archetyper.ex
+++ b/lib/backend/deck_archetyper/hunter_archetyper.ex
@@ -143,6 +143,9 @@ defmodule Backend.DeckArchetyper.HunterArchetyper do
       "Mecha'thun" in card_info.card_names ->
         "Mecha'thun #{class_name}"
 
+      "Floppy Hydra" in card_info.card_names ->
+        :"Floppy Hydra Hunter"
+
       true ->
         fallbacks(card_info, class_name)
     end


### PR DESCRIPTION
Control decks use it as an infinite threat sometimes so I rather put it in hunter instead of a fallback https://www.hsguru.com/decks?format=1&min_games=50&period=patch_29.6.2&player_deck_includes[]=105495