### PR TITLE
Expand wild Thief Rogue definition

### DIFF
--- a/lib/backend/deck_archetyper/rogue_archetyper.ex
+++ b/lib/backend/deck_archetyper/rogue_archetyper.ex
@@ -361,7 +361,8 @@ defmodule Backend.DeckArchetyper.RogueArchetyper do
       "Vendetta",
       "Wildpaw Gnoll",
       "Stick Up",
-      "Flint Firearm"
+      "Flint Firearm",
+      "Thistle Tea Set"
     ])
   end
 


### PR DESCRIPTION
One of the most popular thief cards was missing and some decks were missed because of it https://www.hsguru.com/decks?format=1&min_games=50&no_archetype=yes&order_by=total&period=patch_29.6.2&player_class=ROGUE&player_deck_includes[]=103433 https://www.hsguru.com/card-stats?archetype=Thief+Rogue&format=1&min_drawn_count=25&min_mull_count=0&period=patch_29.6.2&show_counts=yes&sort_by=drawn_count&sort_direction=desc