### PR TITLE
Add Pirate Demon Hunter to wild

### DIFF
--- a/lib/backend/deck_archetyper/demon_hunter_archetyper.ex
+++ b/lib/backend/deck_archetyper/demon_hunter_archetyper.ex
@@ -270,6 +270,9 @@ defmodule Backend.DeckArchetyper.DemonHunterArchetyper do
       "Mecha'thun" in card_info.card_names ->
         "Mecha'thun #{class_name}"
 
+      pirate?(card_info) ->
+        :"Pirate Demon Hunter"
+
       true ->
         fallbacks(card_info, class_name)
     end


### PR DESCRIPTION
Pirate Demon Hunter doesn't always use enough pirates in wild for the fallback to catch it
https://www.hsguru.com/card-stats?archetype=Demonhunter&format=1&min_drawn_count=25&min_mull_count=0&show_counts=yes&sort_by=drawn_count&sort_direction=desc