### PR TITLE
Move Mecha'thun Rogue above Kingsbane Rogue

### DIFF
--- a/lib/backend/deck_archetyper/rogue_archetyper.ex
+++ b/lib/backend/deck_archetyper/rogue_archetyper.ex
@@ -338,6 +338,9 @@ defmodule Backend.DeckArchetyper.RogueArchetyper do
       genn?(card_info) ->
         String.to_atom("Even #{class_name}")
 
+      "Mecha'thun" in card_info.card_names ->
+        "Mecha'thun #{class_name}"
+
       "Kingsbane" in card_info.card_names ->
         :"Kingsbane Rogue"
 
@@ -358,9 +361,6 @@ defmodule Backend.DeckArchetyper.RogueArchetyper do
 
       wild_alex_rogue?(card_info) ->
         :"Alex Rogue"
-
-      "Mecha'thun" in card_info.card_names ->
-        "Mecha'thun #{class_name}"
 
       wild_pirate_rogue?(card_info) ->
         :"Pirate Rogue"


### PR DESCRIPTION
more than half of mecha'thun rogue decks also use kingsbane https://www.hsguru.com/card-stats?archetype=Kingsbane+Rogue&format=1&min_drawn_count=0&min_mull_count=0&show_counts=yes&sort_by=drawn_count&sort_direction=desc