### PR TITLE
Add Mill OTK druid to wild

### DIFF
--- a/lib/backend/deck_archetyper/druid_archetyper.ex
+++ b/lib/backend/deck_archetyper/druid_archetyper.ex
@@ -134,6 +134,9 @@ defmodule Backend.DeckArchetyper.DruidArchetyper do
       wild_mill_druid?(card_info) ->
         :"Mill Druid"
 
+      wild_mill_OTK?(card_info) ->
+        :"Mill OTK Druid"
+
       old_aggro?(card_info) ->
         :"Old Aggro Druid"
 
@@ -187,6 +190,10 @@ defmodule Backend.DeckArchetyper.DruidArchetyper do
 
   defp wild_mill_druid?(card_info) do
     min_count?(card_info, 2, ["Dew Process", "Coldlight Oracle", "Naturalize"])
+  end
+
+  defp wild_mill_OTK?(card_info) do
+    min_count?(card_info, 2, ["Grove Shaper", "Naturalize"])
   end
 
   defp old_aggro?(card_info) do


### PR DESCRIPTION
https://www.hsguru.com/decks?format=1&min_games=50&no_archetype=yes&period=emerald_dream&player_class=DRUID&player_deck_includes[]=115809&rank=all I don't think normal mill that has grove shaper should be called Mill OTK because it doesn't necessarily have to be an OTK, while this does. It could also be called Grove / Grove Shaper Druid.