### PR TITLE
Add Malygos Druid to wild

### DIFF
--- a/lib/backend/deck_archetyper/druid_archetyper.ex
+++ b/lib/backend/deck_archetyper/druid_archetyper.ex
@@ -163,6 +163,9 @@ defmodule Backend.DeckArchetyper.DruidArchetyper do
       "Travelmaster Dungar" in card_info.card_names ->
         :"Dungar Druid"
 
+      "Malygos" in card_info.card_names ->
+        :"Malygos Druid"
+
       aviana_druid?(card_info) ->
         :"Aviana Druid"
 


### PR DESCRIPTION
https://www.hsguru.com/decks?format=1&min_games=50&player_deck_archetype[]=XL+Aviana+Druid
I put it below Dungar Druid because most of those decks already run Malygos.