### PR TITLE
Add Aggro Plague DK to wild and update Aggro DK

### DIFF
--- a/lib/backend/deck_archetyper/death_knight_archetyper.ex
+++ b/lib/backend/deck_archetyper/death_knight_archetyper.ex
@@ -184,6 +184,9 @@ defmodule Backend.DeckArchetyper.DeathKnightArchetyper do
       buttons?(card_info) ->
         :"Buttons DK"
 
+      wild_aggro_dk?(card_info) and plague?(card_info) ->
+        :"Aggro Plague DK"
+
       plague?(card_info) ->
         :"Plague DK"
 
@@ -207,7 +210,7 @@ defmodule Backend.DeckArchetyper.DeathKnightArchetyper do
   end
 
   defp wild_aggro_dk?(card_info) do
-    min_count?(card_info, 2, [
+    min_count?(card_info, 1, [
       "Grave Strength",
       "Anti-Magic Shell",
       "Monstrous Mosquito"


### PR DESCRIPTION
https://www.hsguru.com/decks?format=1&min_games=50&period=patch_32.2.4&player_class[]=DEATHKNIGHT&player_deck_excludes[]=103471&player_deck_includes[]=97683
A lot of Aggro DK decks are missed with the current definition as they only run Grave Strength or Mosquito