### PR TITLE
Update Warlock Archetype names

### DIFF
--- a/lib/backend/deck_archetyper/warlock_archetyper.ex
+++ b/lib/backend/deck_archetyper/warlock_archetyper.ex
@@ -178,7 +178,7 @@ defmodule Backend.DeckArchetyper.WarlockArchetyper do
   def wild(card_info) do
     cond do
       highlander?(card_info) ->
-        :"Renolock"
+        :"Highlander Warlock"
 
       "The Demon Seed" in card_info.card_names ->
         :"Seedlock"


### PR DESCRIPTION
The popularity of Renolock to Highlander/HL is 12 : 1 for Warlock so I think it is warranted