### PR TITLE
Add other Chad Warrior archetypes to wild

### DIFF
--- a/lib/backend/deck_archetyper/warrior_archetyper.ex
+++ b/lib/backend/deck_archetyper/warrior_archetyper.ex
@@ -146,6 +146,12 @@ defmodule Backend.DeckArchetyper.WarriorArchetyper do
       "Dead Man's Hand" in card_info.card_names ->
         :"DMH Warrior"
 
+      "Rivendare, Warrider" in card_info.card_names ->
+        :"Rivendare Warrior"
+
+      "Mecha'thun" in card_info.etc_sideboard_names and "Thaddius, Monstrosity" in card_info.card_names ->
+        :"Mecha'Chad Warrior"
+
       "Thaddius, Monstrosity" in card_info.card_names ->
         :"Chad Warrior"
 


### PR DESCRIPTION
https://www.hsguru.com/decks?format=1&min_games=50&period=patch_32.4.2&player_class[]=WARRIOR&player_deck_excludes[]=46589&player_deck_includes[]=86722
"Chad Mecha'thun Warrior" doesn't fit and I don't have a better idea