### PR TITLE
Add Heal Burn Priest to wild

### DIFF
--- a/lib/backend/deck_archetyper/priest_archetyper.ex
+++ b/lib/backend/deck_archetyper/priest_archetyper.ex
@@ -150,6 +150,9 @@ defmodule Backend.DeckArchetyper.PriestArchetyper do
       highlander?(card_info) ->
         :"Highlander Priest"
 
+      wild_heal_burn_priest?(card_info) ->
+        :"Heal Burn Priest"
+
       questline?(card_info) ->
         :"Questline Priest"
 
@@ -250,6 +253,13 @@ defmodule Backend.DeckArchetyper.PriestArchetyper do
       "Intertwined Fate",
       "Keymaster Alabaster",
       "Cloning Device"
+    ])
+  end
+
+  defp wild_heal_burn_priest?(card_info) do
+    min_count?(card_info, 2, [
+      "Cleansing Cleric",
+      "Embrace the Shadow"
     ])
   end
 


### PR DESCRIPTION
https://www.hsguru.com/decks?format=1&min_games=50&period=patch_35.0.3&player_class[]=PRIEST&player_deck_includes[]=123426&player_deck_includes[]=38439
The quests are used as enablers for medivh's triumph, not as the main wincon.